### PR TITLE
GSoC 2013 application bugfix: totp offset and replay logging

### DIFF
--- a/libdynalogin/dynalogin.c
+++ b/libdynalogin/dynalogin.c
@@ -267,7 +267,19 @@ dynalogin_result_t dynalogin_authenticate_internal
 		else
 		{
 			fail_inc = 0;
+			syslog(LOG_WARNING, "Token replay detected, denying authentication");
 			rc = OATH_REPLAYED_OTP;
+		}
+		/* totp_offset only contains a valid value if the OTP was 
+		   inside the specified window - in that case the rc is the 
+		   absolute offset */
+		if(rc>=0 && totp_offset < 0) 
+		{
+		    syslog(LOG_WARNING, "TOTP validation returned offset %d (~%d seconds behind)",totp_offset,rc*h->totp_x);
+		}
+		else if(rc > 0)
+		{
+		    syslog(LOG_WARNING, "TOTP validation returned offset %d (~%d seconds ahead)",totp_offset,rc*h->totp_x);
 		}
 		break;
 	default:


### PR DESCRIPTION
See http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=705939

Sample output for replayed OTP values:

Apr 29 15:02:51 debian /usr/sbin/dynalogind[11386]: new incoming connection
Apr 29 15:02:51 debian /usr/sbin/dynalogind[11386]: attempting DYNALOGIN auth for user=testuser
Apr 29 15:02:51 debian /usr/sbin/dynalogind[11386]: user = testuser, count = 45574687
Apr 29 15:02:51 debian /usr/sbin/dynalogind[11386]: Token replay detected, denying authentication
Apr 29 15:02:51 debian /usr/sbin/dynalogind[11386]: updated data: user = testuser, count = 45574687
Apr 29 15:02:51 debian /usr/sbin/dynalogind[11386]: DYNALOGIN denied for user=testuser
Apr 29 15:02:51 debian /usr/sbin/dynalogind[11386]: client connection closed

Sample output for offset logging:

Apr 29 15:04:03 debian /usr/sbin/dynalogind[11386]: new incoming connection
Apr 29 15:04:04 debian /usr/sbin/dynalogind[11386]: attempting DYNALOGIN auth for user=testuser
Apr 29 15:04:04 debian /usr/sbin/dynalogind[11386]: user = testuser, count = 45574687
Apr 29 15:04:04 debian /usr/sbin/dynalogind[11386]: TOTP validation returned offset 2 (~60 seconds ahead)
Apr 29 15:04:04 debian /usr/sbin/dynalogind[11386]: updated data: user = testuser, count = 45574691
Apr 29 15:04:04 debian /usr/sbin/dynalogind[11386]: DYNALOGIN success for user=testuser
Apr 29 15:04:04 debian /usr/sbin/dynalogind[11386]: client connection closed
