### PR TITLE
Fix FTBFS with clang instead of gcc

### DIFF
--- a/dynalogind/dynalogind.c
+++ b/dynalogind/dynalogind.c
@@ -76,7 +76,7 @@ apr_status_t read_line(apr_pool_t *pool, socket_thread_data_t *td,
 	{
 		syslog(LOG_ERR, "read_line: apr_pcalloc failed");
 		apr_pool_destroy(pool);
-		return;
+		return 0;
 	}
 	_buf = *buf;
 


### PR DESCRIPTION
This will fix the non-void function should return a value error.
