### PR TITLE
Add log to console fallback to openlog().

### DIFF
--- a/dynalogind/dynalogind.c
+++ b/dynalogind/dynalogind.c
@@ -547,7 +547,7 @@ int main(int argc, char *argv[])
 	/* Just return an error if a client closes a socket */
 	apr_signal_block(SIGPIPE);
 
-	openlog(argv[0], LOG_PID, LOG_AUTHPRIV);
+	openlog(argv[0], LOG_PID | LOG_CONS, LOG_AUTHPRIV);
 
 	if((res = apr_pool_create(&pool, NULL)) != APR_SUCCESS)
 	{


### PR DESCRIPTION
Patches openlog() call to allow safe fallback if no syslog service is present, as it will be the case always inside a Docker container. See man syslog(3).